### PR TITLE
Refactor issue creation logic to return URL and Node ID as a tuple

### DIFF
--- a/src/github_automation_tool/adapters/cli_reporter.py
+++ b/src/github_automation_tool/adapters/cli_reporter.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 # domain/models.py から結果用データクラスをインポートすることを想定
 # (CreateIssuesResult は前回定義済み)
@@ -26,18 +26,21 @@ class CliReporter:
         repo_info = f" for repository '{repo_full_name}'" if repo_full_name else ""
         # --- 結果のサマリーを INFO レベルで表示 ---
         logger.info(f"--- Issue Creation Summary{repo_info} ---")
+        created_count = len(result.created_issue_details)
+        skipped_count = len(result.skipped_issue_titles)
+        failed_count = len(result.failed_issue_titles)
         summary = (
-            f"Total processed: {len(result.created_issue_urls) + len(result.skipped_issue_titles) + len(result.failed_issue_titles)}, "
-            f"Created: {len(result.created_issue_urls)}, "
-            f"Skipped: {len(result.skipped_issue_titles)}, "
-            f"Failed: {len(result.failed_issue_titles)}"
+            f"Total processed: {created_count + skipped_count + failed_count}, "
+            f"Created: {created_count}, "
+            f"Skipped: {skipped_count}, "
+            f"Failed: {failed_count}"
         )
         logger.info(summary)
 
         # --- 各詳細情報を適切なログレベルで表示 ---
-        if result.created_issue_urls:
+        if result.created_issue_details:
             logger.info("[Created Issues]")
-            for url in result.created_issue_urls:
+            for url, node_id in result.created_issue_details:
                 logger.info(f"- {url}")
 
         if result.skipped_issue_titles:

--- a/src/github_automation_tool/domain/models.py
+++ b/src/github_automation_tool/domain/models.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel, Field, ConfigDict
+# Removed typing imports; using built-in generics for Python 3.13
 
 
 class IssueData(BaseModel):
@@ -47,9 +48,9 @@ class CreateIssuesResult(BaseModel):
     CreateIssuesUseCase の実行結果を格納するデータクラス。
     どのIssueが作成され、スキップされ、失敗したかの情報を持つ。
     """
-    created_issue_urls: list[str] = Field(
-        default_factory=list,  # デフォルト値を空リストにする
-        description="正常に作成されたIssueのGitHub URLリスト"
+    created_issue_details: list[tuple[str, str]] = Field(
+        default_factory=list,
+        description="正常に作成されたIssueの (GitHub URL, Node ID) タプルのリスト"
     )
     skipped_issue_titles: list[str] = Field(
         default_factory=list,

--- a/tests/adapters/test_cli_reporter.py
+++ b/tests/adapters/test_cli_reporter.py
@@ -16,7 +16,7 @@ def reporter() -> CliReporter:
 
 def test_display_issue_creation_success_only(reporter: CliReporter, caplog):
     """Issue作成がすべて成功した場合のログ出力テスト"""
-    result = CreateIssuesResult(created_issue_urls=["https://github.com/test/repo/issues/1", "https://github.com/test/repo/issues/2"])
+    result = CreateIssuesResult(created_issue_details=[("https://github.com/test/repo/issues/1", "node_id_1"), ("https://github.com/test/repo/issues/2", "node_id_2")])
     # テスト実行中のログレベルをINFO以上に設定してキャプチャ
     with caplog.at_level(logging.INFO):
         reporter.display_issue_creation_result(result, "owner/repo")
@@ -64,7 +64,7 @@ def test_display_issue_creation_failed_only(reporter: CliReporter, caplog):
 def test_display_issue_creation_mixed(reporter: CliReporter, caplog):
     """成功・スキップ・失敗が混在する場合のログ出力テスト"""
     result = CreateIssuesResult(
-        created_issue_urls=["https://good.url/1"],
+        created_issue_details=[("https://good.url/1", "node_good")],
         skipped_issue_titles=["Already There"],
         failed_issue_titles=["Bad One"],
         errors=["API Error 500"]

--- a/tests/use_cases/test_create_issues.py
+++ b/tests/use_cases/test_create_issues.py
@@ -14,7 +14,8 @@ def mock_github_client() -> MagicMock:
     mock = MagicMock(spec=GitHubAppClient)
     # メソッドもモック化しておく
     mock.find_issue_by_title = MagicMock()
-    mock.create_issue = MagicMock()
+    # create_issue がタプル (url, node_id) を返すようにモック
+    mock.create_issue = MagicMock(return_value=("default_url", "default_node_id"))
     return mock
 
 @pytest.fixture
@@ -44,12 +45,13 @@ def test_execute_all_new_issues(create_issues_use_case: CreateIssuesUseCase, moc
     """全てのIssueが新規の場合、全て作成されることをテスト"""
     # モック設定: 存在確認は常にFalse、作成は成功しURLを返す
     mock_github_client.find_issue_by_title.return_value = False
-    mock_github_client.create_issue.side_effect = ["url/1", "url/3"] # 呼び出し順に対応
+    # create_issue は URL,node_id タプルを返すように設定
+    mock_github_client.create_issue.side_effect = [("url/1", "node_id_1"), ("url/3", "node_id_3")]
 
     result = create_issues_use_case.execute(PARSED_DATA_ALL_NEW, TEST_OWNER, TEST_REPO)
 
     assert isinstance(result, CreateIssuesResult)
-    assert result.created_issue_urls == ["url/1", "url/3"]
+    assert result.created_issue_details == [("url/1", "node_id_1"), ("url/3", "node_id_3")]
     assert result.skipped_issue_titles == []
     assert result.failed_issue_titles == []
     assert result.errors == []
@@ -61,8 +63,8 @@ def test_execute_all_new_issues(create_issues_use_case: CreateIssuesUseCase, moc
     ])
     assert mock_github_client.create_issue.call_count == 2
     mock_github_client.create_issue.assert_has_calls([
-        call(owner=TEST_OWNER, repo=TEST_REPO, title=ISSUE1_DATA.title, body=ISSUE1_DATA.body),
-        call(owner=TEST_OWNER, repo=TEST_REPO, title=ISSUE3_DATA.title, body=ISSUE3_DATA.body)
+        call(owner=TEST_OWNER, repo=TEST_REPO, title=ISSUE1_DATA.title, body=ISSUE1_DATA.body, labels=None, milestone=None, assignees=None),
+        call(owner=TEST_OWNER, repo=TEST_REPO, title=ISSUE3_DATA.title, body=ISSUE3_DATA.body, labels=None, milestone=None, assignees=None)
     ])
 
 def test_execute_all_existing_issues(create_issues_use_case: CreateIssuesUseCase, mock_github_client: MagicMock):
@@ -72,7 +74,7 @@ def test_execute_all_existing_issues(create_issues_use_case: CreateIssuesUseCase
 
     result = create_issues_use_case.execute(PARSED_DATA_ALL_EXISTING, TEST_OWNER, TEST_REPO)
 
-    assert result.created_issue_urls == []
+    assert result.created_issue_details == []
     assert result.skipped_issue_titles == [ISSUE2_DATA.title]
     assert result.failed_issue_titles == []
     assert result.errors == []
@@ -86,11 +88,11 @@ def test_execute_mixed_issues(create_issues_use_case: CreateIssuesUseCase, mock_
         return title == ISSUE2_DATA.title
     mock_github_client.find_issue_by_title.side_effect = find_side_effect
     # create は2回呼ばれる想定
-    mock_github_client.create_issue.side_effect = ["url/1", "url/3"]
+    mock_github_client.create_issue.side_effect = [("url/1", "node_id_1"), ("url/3", "node_id_3")]
 
     result = create_issues_use_case.execute(PARSED_DATA_MIXED, TEST_OWNER, TEST_REPO)
 
-    assert result.created_issue_urls == ["url/1", "url/3"]
+    assert result.created_issue_details == [("url/1", "node_id_1"), ("url/3", "node_id_3")]
     assert result.skipped_issue_titles == [ISSUE2_DATA.title]
     assert result.failed_issue_titles == []
     assert result.errors == []
@@ -103,14 +105,12 @@ def test_execute_find_issue_api_error(create_issues_use_case: CreateIssuesUseCas
     # モック設定: 最初の find でエラー、次は False、最後は True
     mock_github_client.find_issue_by_title.side_effect = [mock_error, False, True]
     # create_issue は2回目の find が False (ISSUE2) なので1回だけ呼ばれる想定
-    mock_github_client.create_issue.return_value = "url/for_issue2" # 返り値を明確に
+    mock_github_client.create_issue.return_value = ("url/for_issue2", "node_for_issue2")
 
     result = create_issues_use_case.execute(PARSED_DATA_MIXED, TEST_OWNER, TEST_REPO)
 
-    # --- ★ アサーション修正 ★ ---
-    assert result.created_issue_urls == ["url/for_issue2"] # 2番目のIssueが作成される
-    # assert result.skipped_issue_titles == [ISSUE2_DATA.title] # ← 誤り
-    assert result.skipped_issue_titles == [ISSUE3_DATA.title] # ← 正: 3番目のIssueがスキップされる
+    assert result.created_issue_details == [("url/for_issue2", "node_for_issue2")] # 2番目のIssueが作成される
+    assert result.skipped_issue_titles == [ISSUE3_DATA.title]  # 3番目のIssueがスキップされる
     assert result.failed_issue_titles == [ISSUE1_DATA.title] # 1番目のIssueは find で失敗
     assert len(result.errors) == 1
     assert "Find API Error" in result.errors[0] # またはより具体的なエラーメッセージ
@@ -120,7 +120,7 @@ def test_execute_find_issue_api_error(create_issues_use_case: CreateIssuesUseCas
     assert mock_github_client.create_issue.call_count == 1 # 2番目のIssue作成時のみ呼ばれる
     # create_issue が正しい引数で呼ばれたか確認
     mock_github_client.create_issue.assert_called_once_with(
-        owner=TEST_OWNER, repo=TEST_REPO, title=ISSUE2_DATA.title, body=ISSUE2_DATA.body
+        owner=TEST_OWNER, repo=TEST_REPO, title=ISSUE2_DATA.title, body=ISSUE2_DATA.body, labels=None, milestone=None, assignees=None
     )
 
 def test_execute_create_issue_api_error(create_issues_use_case: CreateIssuesUseCase, mock_github_client: MagicMock):
@@ -128,11 +128,11 @@ def test_execute_create_issue_api_error(create_issues_use_case: CreateIssuesUseC
     mock_error = GitHubValidationError("Create API Error", status_code=422)
     # モック設定: find は全て False、create の2番目 (ISSUE4) でエラー
     mock_github_client.find_issue_by_title.return_value = False
-    mock_github_client.create_issue.side_effect = ["url/1", mock_error, "url/3"]
+    mock_github_client.create_issue.side_effect = [("url/1", "node1"), mock_error, ("url/3", "node3")]
 
     result = create_issues_use_case.execute(PARSED_DATA_WITH_ERROR, TEST_OWNER, TEST_REPO)
 
-    assert result.created_issue_urls == ["url/1", "url/3"] # 1, 3番目は成功
+    assert result.created_issue_details == [("url/1", "node1"), ("url/3", "node3")] # 1, 3番目は成功
     assert result.skipped_issue_titles == []
     assert result.failed_issue_titles == [ISSUE4_DATA.title] # 4番目は create で失敗
     assert len(result.errors) == 1
@@ -144,7 +144,7 @@ def test_execute_empty_issue_list(create_issues_use_case: CreateIssuesUseCase, m
     """Issueリストが空の場合、何も処理されないことをテスト"""
     result = create_issues_use_case.execute(PARSED_DATA_EMPTY_ISSUES, TEST_OWNER, TEST_REPO)
 
-    assert result.created_issue_urls == []
+    assert result.created_issue_details == []
     assert result.skipped_issue_titles == []
     assert result.failed_issue_titles == []
     assert result.errors == []
@@ -155,11 +155,11 @@ def test_execute_with_empty_title(create_issues_use_case: CreateIssuesUseCase, m
     """タイトルが空のIssueデータが含まれている場合、スキップされるかテスト"""
     # モック設定: find は False, create は成功する想定
     mock_github_client.find_issue_by_title.return_value = False
-    mock_github_client.create_issue.return_value = "url/1"
+    mock_github_client.create_issue.return_value = ("url/1", "node_id_1")
 
     result = create_issues_use_case.execute(PARSED_DATA_WITH_EMPTY_TITLE, TEST_OWNER, TEST_REPO)
 
-    assert result.created_issue_urls == ["url/1"] # ISSUE1のみ作成
+    assert result.created_issue_details == [("url/1", "node_id_1")] # ISSUE1のみ作成
     assert result.skipped_issue_titles == []
     assert result.failed_issue_titles == ["(Empty Title)"] # タイトル無しは失敗扱い
     assert len(result.errors) == 1
@@ -167,4 +167,8 @@ def test_execute_with_empty_title(create_issues_use_case: CreateIssuesUseCase, m
     assert mock_github_client.find_issue_by_title.call_count == 1 # ISSUE1のみfindが呼ばれる
     mock_github_client.find_issue_by_title.assert_called_once_with(TEST_OWNER, TEST_REPO, ISSUE1_DATA.title)
     assert mock_github_client.create_issue.call_count == 1 # ISSUE1のみcreateが呼ばれる
-    mock_github_client.create_issue.assert_called_once_with(owner=TEST_OWNER, repo=TEST_REPO, title=ISSUE1_DATA.title, body=ISSUE1_DATA.body)
+    mock_github_client.create_issue.assert_called_once_with(
+        owner=TEST_OWNER, repo=TEST_REPO,
+        title=ISSUE1_DATA.title, body=ISSUE1_DATA.body,
+        labels=ISSUE1_DATA.labels, milestone=ISSUE1_DATA.milestone, assignees=ISSUE1_DATA.assignees
+    )


### PR DESCRIPTION
- Updated CreateIssuesResult to store created issue details as a list of tuples (URL, Node ID).
- Modified CreateIssuesUseCase to handle the new return type from the GitHub client when creating issues.
- Adjusted tests to reflect changes in the data structure for created issues, ensuring proper assertions for URLs and Node IDs.
- Enhanced error handling for issue creation failures, logging appropriate messages.
- Added new tests for GraphQL methods related to project management, ensuring robust error handling and input validation.